### PR TITLE
[Feat-22] Jwt 토큰 인증 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.security:spring-security-core")
 
+    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
+
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/WebMvcConfig.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/WebMvcConfig.kt
@@ -1,0 +1,16 @@
+package com.teamsparta.exhibitionnewsfeed
+
+import com.teamsparta.exhibitionnewsfeed.auth.AuthArgumentResolver
+import com.teamsparta.exhibitionnewsfeed.auth.JwtTokenProvider
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val jwtTokenProvider: JwtTokenProvider
+) : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(AuthArgumentResolver(jwtTokenProvider))
+    }
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/AuthArgumentResolver.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/AuthArgumentResolver.kt
@@ -1,0 +1,37 @@
+package com.teamsparta.exhibitionnewsfeed.auth
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+
+@Component
+class AuthArgumentResolver(
+    private val jwtTokenProvider: JwtTokenProvider
+) : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(RequestUser::class.java) && parameter.parameterType.isAssignableFrom(
+            AuthUser::class.java
+        )
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        val request: HttpServletRequest =
+            webRequest.getNativeRequest(HttpServletRequest::class.java) ?: throw IllegalArgumentException()
+        val token = request.getHeader(HttpHeaders.AUTHORIZATION)?.replace("Bearer ", "")?.trim() ?: ""
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw IllegalArgumentException("Invalid Token")
+        }
+        return AuthUser(jwtTokenProvider.getUserId(token))
+    }
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/AuthConfig.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/AuthConfig.kt
@@ -7,9 +7,14 @@ import org.springframework.security.crypto.password.PasswordEncoder
 
 @Configuration
 class AuthConfig {
-    
+
     @Bean
     fun passwordEncoder(): PasswordEncoder {
         return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    fun jwtTokenProvider(): JwtTokenProvider {
+        return JwtTokenProvider()
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/AuthUser.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/AuthUser.kt
@@ -1,0 +1,5 @@
+package com.teamsparta.exhibitionnewsfeed.auth
+
+data class AuthUser(
+    val id: Long
+)

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/JwtTokenProvider.kt
@@ -1,0 +1,60 @@
+package com.teamsparta.exhibitionnewsfeed.auth
+
+import com.teamsparta.exhibitionnewsfeed.domain.user.model.User
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.security.Keys
+import io.jsonwebtoken.security.SignatureException
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import javax.crypto.SecretKey
+
+class JwtTokenProvider {
+    companion object {
+        const val SECRET_KEY = "IguOg/KpN3c0VVRkfjxnlDXXkLx/cXUxzuGM5UKAevI="
+    }
+
+    private val key: SecretKey = Keys.hmacShaKeyFor(SECRET_KEY.toByteArray(StandardCharsets.UTF_8))
+
+    fun generateToken(user: User): String {
+        val claims = Jwts.claims().add("userId", user.id).build()
+        val now = Instant.now()
+
+        return Jwts.builder()
+            .subject("accessToken")
+            .issuer("team6.explorers")
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plus(Duration.ofHours(3))))
+            .claims(claims)
+            .signWith(key)
+            .compact()
+    }
+
+    fun validateToken(token: String): Boolean {
+        try {
+            Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+        } catch (e: MalformedJwtException) {
+            throw IllegalArgumentException("Invalid Token")
+        } catch (e: SignatureException) {
+            throw IllegalArgumentException("Invalid Token")
+        } catch (e: ExpiredJwtException) {
+            throw IllegalArgumentException("Expired Token")
+        }
+        return true
+    }
+
+    fun getUserId(token: String): Long {
+        val payload = Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .payload
+        return payload["userId"].toString().toLong()
+    }
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/RequestUser.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/auth/RequestUser.kt
@@ -1,0 +1,5 @@
+package com.teamsparta.exhibitionnewsfeed.auth
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RequestUser()

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/dto/LoginResponse.kt
@@ -3,11 +3,11 @@ package com.teamsparta.exhibitionnewsfeed.domain.user.dto
 import com.teamsparta.exhibitionnewsfeed.domain.user.model.User
 
 data class LoginResponse(
-    val user: UserResponse
-    //TODO token 정보
+    val user: UserResponse,
+    val accessToken: String
 ) {
     companion object {
-        fun from(user: User) = LoginResponse(user = user.toResponse())
+        fun from(user: User, token: String) = LoginResponse(user = user.toResponse(), accessToken = token)
     }
 }
 

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/service/UserServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.exhibitionnewsfeed.domain.user.service
 
+import com.teamsparta.exhibitionnewsfeed.auth.JwtTokenProvider
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.LoginRequest
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.LoginResponse
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.SignUpRequest
@@ -12,7 +13,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserServiceImpl(
     private val userRepository: UserRepository,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtTokenProvider: JwtTokenProvider
 ) : UserService {
 
     @Transactional
@@ -28,6 +30,8 @@ class UserServiceImpl(
                 passwordEncoder
             )
         ) throw IllegalArgumentException("잘못된 Email/PW 입니다.")
-        return LoginResponse.from(user)
+
+        val token = jwtTokenProvider.generateToken(user)
+        return LoginResponse.from(user, token)
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/exception/GlobalExceptionHandler.kt
@@ -37,6 +37,11 @@ class GlobalExceptionHandler {
     fun handleModelNotFoundException(e: ModelNotFoundException): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(message = e.message))
     }
-
-
+    
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(message = e.message))
+    }
 }


### PR DESCRIPTION
## 작업 사항
- jwt 사용을 위해 jjwt dependency 추가
- 로그인시 jwt 토큰 발급
- jwt로 인증 기능 구현
  - 컨트롤러에서 @RequestUser 어노테이션을 사용하여 클라이언트 요청시 헤더에 담긴 Authorization 토큰 검증

완료할 이슈: #22 