### PR TITLE
[Feat 23] 해시태그 기능 구현

### DIFF
--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/CreatePostRequest.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto
 
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.HashTag
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.Post
 import com.teamsparta.exhibitionnewsfeed.domain.user.model.User
 import jakarta.validation.constraints.NotBlank
@@ -12,6 +13,8 @@ data class CreatePostRequest(
 
     @field:NotBlank
     val content: String,
+
+    val tagName: String
 )
 
 fun CreatePostRequest.toEntity(user: User): Post {
@@ -22,7 +25,7 @@ fun CreatePostRequest.toEntity(user: User): Post {
     )
 }
 
-fun CreatePostRequest.toHashTagEntity(): HashTag {
+fun toHashTagEntity(tagName: String): HashTag {
     return HashTag(
         tagName = tagName
     )

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/CreatePostRequest.kt
@@ -20,7 +20,10 @@ fun CreatePostRequest.toEntity(user: User): Post {
         content = this.content,
         user = user //TODO: 로그인 구현 후 다른방식으로 수정
     )
-
 }
 
-
+fun CreatePostRequest.toHashTagEntity(): HashTag {
+    return HashTag(
+        tagName = tagName
+    )
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/HashTagResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/HashTagResponse.kt
@@ -1,0 +1,6 @@
+package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto
+
+data class HashTagResponse(
+    val id: Long,
+    val tagName: String
+)

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/HashTagResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/HashTagResponse.kt
@@ -1,6 +1,17 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto
 
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.HashTag
+
 data class HashTagResponse(
     val id: Long,
     val tagName: String
-)
+) {
+    companion object {
+        fun from(hashTag: HashTag): HashTagResponse {
+            return HashTagResponse(
+                hashTag.id ?: throw IllegalStateException("User ID cannot be null"),
+                hashTag.tagName
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostResponse.kt
@@ -11,6 +11,7 @@ data class PostResponse(
     val createdAt: LocalDateTime?,
     val updateAt: LocalDateTime?,
     val user: UserResponse,
+    val postTag: List<PostTagResponse>,
     val comments: List<CommentResponse>
 ) {
     companion object {
@@ -21,7 +22,9 @@ data class PostResponse(
                 post.createdAt,
                 post.updatedAt,
                 post.user.toResponse(),
-                post.comments.map { CommentResponse.from(it) })
+                post.postTag.map { PostTagResponse.from(it) },
+                post.comments.map { CommentResponse.from(it) }
+            )
         }
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostTagResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostTagResponse.kt
@@ -1,0 +1,15 @@
+package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto
+
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.PostTag
+
+data class PostTagResponse(
+    val hashTag: HashTagResponse
+) {
+    companion object {
+        fun from(postTag: PostTag): PostTagResponse {
+            return PostTagResponse(
+                postTag.hashTag.toResponse()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostTagResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostTagResponse.kt
@@ -7,9 +7,8 @@ data class PostTagResponse(
 ) {
     companion object {
         fun from(postTag: PostTag): PostTagResponse {
-            return PostTagResponse(
-                postTag.hashTag.toResponse()
-            )
+            return PostTagResponse(HashTagResponse.from(postTag.hashTag))
         }
     }
 }
+

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostsResponse.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/PostsResponse.kt
@@ -1,24 +1,25 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto
 
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.Post
-import com.teamsparta.exhibitionnewsfeed.domain.user.model.User
 import java.time.LocalDateTime
 
 data class PostsResponse(
     val id: Long,
     val title: String,
     val content: String,
-    val user: User,
+    val user: String,
     val createdAt: LocalDateTime?,
+    val postTag: List<PostTagResponse>
 ) {
     companion object {
-        fun Post.toResponse(): PostsResponse {
+        fun from(post: Post): PostsResponse {
             return PostsResponse(
-                id = id ?: throw IllegalStateException("ID cannot be Null"),
-                title = title,
-                content = content,
-                createdAt = createdAt,
-                user = user,
+                post.id ?: throw IllegalStateException("ID cannot be Null"),
+                post.title,
+                post.content,
+                post.user.toResponse().nickname,
+                post.createdAt,
+                post.postTag.map { PostTagResponse.from(it) }
             )
         }
     }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/dto/UpdatePostRequest.kt
@@ -5,5 +5,7 @@ data class UpdatePostRequest(
 
     val content: String,
 
-    val userId: Long
+    val userId: Long,
+
+    val tagName: String
 )

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/HashTag.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/HashTag.kt
@@ -1,6 +1,5 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model
 
-import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.HashTagResponse
 import jakarta.persistence.*
 
 @Entity
@@ -9,18 +8,8 @@ class HashTag(
 
     @Column(name = "tagName")
     var tagName: String,
-
-    @OneToMany(mappedBy = "hashTag", cascade = [(CascadeType.ALL)], orphanRemoval = true)
-    val postTag: MutableList<PostTag> = mutableListOf(),
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
-
-    fun toResponse(): HashTagResponse {
-        return HashTagResponse(
-            id = this.id ?: throw IllegalStateException("User ID cannot be null"),
-            tagName = this.tagName,
-        )
-    }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/HashTag.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/HashTag.kt
@@ -1,13 +1,26 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model
 
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.HashTagResponse
 import jakarta.persistence.*
 
 @Entity
+@Table(name = "hashtag")
 class HashTag(
-    @Column(name = "tag-name")
-    val tagName: String,
+
+    @Column(name = "tagName")
+    var tagName: String,
+
+    @OneToMany(mappedBy = "hashTag", cascade = [(CascadeType.ALL)], orphanRemoval = true)
+    val postTag: MutableList<PostTag> = mutableListOf(),
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
+
+    fun toResponse(): HashTagResponse {
+        return HashTagResponse(
+            id = this.id ?: throw IllegalStateException("User ID cannot be null"),
+            tagName = this.tagName,
+        )
+    }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/Post.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/Post.kt
@@ -23,7 +23,7 @@ class Post(
     @OneToMany(mappedBy = "post", cascade = [(CascadeType.ALL)])
     val comments: List<Comment> = emptyList(),
 
-    @OneToMany(mappedBy = "post", cascade = [(CascadeType.ALL)], orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = [(CascadeType.ALL)])
     var postTag: MutableList<PostTag> = mutableListOf(),
 ) : BaseTime() {
     @Id
@@ -36,5 +36,18 @@ class Post(
         if (user.id != request.userId) {
             throw ComparativeVerificationException(request.userId)
         }
+    }
+
+    fun hashTagList(hashTag: String): List<String> {
+        var tagList = mutableListOf<String>()
+        if ("^[\\sㄱ-ㅎ가-힣a-zA-Z0-9,]*$".toRegex().matches(hashTag)) {
+            hashTag.split(",").forEach {
+                val s = it.trim()
+                if (s.isNotBlank()) tagList.add(s)
+            }
+        } else {
+            return throw IllegalArgumentException("잘못된 형식의 태그입니다.(특수문자 불가, 구분자: 쉼표(,))")
+        }
+        return tagList
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/Post.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/Post.kt
@@ -21,7 +21,10 @@ class Post(
     var user: User,
 
     @OneToMany(mappedBy = "post", cascade = [(CascadeType.ALL)])
-    val comments: List<Comment> = emptyList()
+    val comments: List<Comment> = emptyList(),
+
+    @OneToMany(mappedBy = "post", cascade = [(CascadeType.ALL)], orphanRemoval = true)
+    var postTag: MutableList<PostTag> = mutableListOf(),
 ) : BaseTime() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/PostTag.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/PostTag.kt
@@ -3,11 +3,14 @@ package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model
 import jakarta.persistence.*
 
 @Entity
+@Table(name = "post_tag")
 class PostTag(
     @ManyToOne
+    @JoinColumn(name = "post_id")
     val post: Post,
 
     @ManyToOne
+    @JoinColumn(name = "hashtag_id")
     val hashTag: HashTag
 ) {
     @Id

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/repository/HashTagRepository.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/repository/HashTagRepository.kt
@@ -1,0 +1,7 @@
+package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository
+
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.HashTag
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface HashTagRepository : JpaRepository<HashTag, Long> {
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/repository/HashTagRepository.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/repository/HashTagRepository.kt
@@ -4,4 +4,6 @@ import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.HashTag
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface HashTagRepository : JpaRepository<HashTag, Long> {
+    fun findHashTagByTagName(tagName: String): HashTag?
+    fun findIdByTagName(tagName: String): HashTag
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/repository/PostTagRepository.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/repository/PostTagRepository.kt
@@ -1,0 +1,7 @@
+package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository
+
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.PostTag
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostTagRepository : JpaRepository<PostTag, Long> {
+}

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/service/PostServiceImpl.kt
@@ -53,8 +53,20 @@ class PostServiceImpl(
     @Transactional
     override fun updatePost(postId: Long, request: UpdatePostRequest): PostResponse {
         val foundPost = postRepository.findByIdOrNull(postId) ?: throw ModelNotFoundException("Post", postId)
+        val tagName = request.tagName
+
         foundPost.updatePostField(request)
 
+        if (tagName.isNotBlank()) {
+            val tagList = foundPost.hashTagList(tagName)
+            tagList.forEach { tag ->
+                if (hashTagRepository.findHashTagByTagName(tag)?.tagName == tag) {
+                    throw IllegalStateException("TagName: $tag already exists")
+                } else {
+                    createHashTag(tag, foundPost)
+                }
+            }
+        }
         return PostResponse.from(foundPost)
     }
 

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/service/PostServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.service
 
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.*
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.Post
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.PostTag
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository.HashTagRepository
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository.PostRepository
@@ -9,6 +10,7 @@ import com.teamsparta.exhibitionnewsfeed.domain.user.repository.UserRepository
 import com.teamsparta.exhibitionnewsfeed.exception.ModelNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class PostServiceImpl(
@@ -28,24 +30,20 @@ class PostServiceImpl(
         return postRepository.findAllByOrderByCreatedAtDesc().map { PostsResponse.from(it) }
     }
 
+    @Transactional
     override fun createPost(request: CreatePostRequest): PostsResponse {
         // TODO: 로그인 구현 후 nickname 가져오는 방식 수정
         val user = userRepository.findByIdOrNull(1L) ?: throw ModelNotFoundException("User", 1)
+        val tagName = request.tagName
 
         var savePost = postRepository.save(request.toEntity(user))
-        if (request.tagName.isNotBlank()) {
-            val saveHashTag = hashTagRepository.save(request.toHashTagEntity())
-            val postTag = postTagRepository.save<PostTag?>(
-                PostTag(
-                    post = savePost,
-                    hashTag = saveHashTag
-                )
-            )
-            savePost.postTag = mutableListOf(postTag)
-        }
+
+        saveHashTags(tagName, savePost)
+
         return PostsResponse.from(savePost)
     }
 
+    @Transactional
     override fun updatePost(postId: Long, request: UpdatePostRequest): PostResponse {
         val foundPost = postRepository.findByIdOrNull(postId) ?: throw ModelNotFoundException("Post", postId)
         foundPost.updatePostField(request)
@@ -53,8 +51,37 @@ class PostServiceImpl(
         return PostResponse.from(foundPost)
     }
 
+    @Transactional
     override fun deletePost(postId: Long) {
         val foundPost = postRepository.findByIdOrNull(postId) ?: throw ModelNotFoundException("Post", postId)
         postRepository.delete(foundPost)
+    }
+
+    private fun saveHashTags(tagName: String, savePost: Post): Post {
+        if (tagName.isNotBlank()) {
+            val tagList = savePost.hashTagList(tagName)
+            tagList.forEach { tag ->
+                if (hashTagRepository.findHashTagByTagName(tag)?.tagName == tag) {
+                    val saveHashTagId = hashTagRepository.findIdByTagName(tag)
+                    val savePostTag = postTagRepository.save<PostTag?>(
+                        PostTag(
+                            post = savePost,
+                            hashTag = saveHashTagId
+                        )
+                    )
+                    savePost.postTag.add(savePostTag)
+                } else {
+                    val saveHashTag = hashTagRepository.save(toHashTagEntity(tag))
+                    val savePostTag = postTagRepository.save<PostTag?>(
+                        PostTag(
+                            post = savePost,
+                            hashTag = saveHashTag
+                        )
+                    )
+                    savePost.postTag.add(savePostTag)
+                }
+            }
+        }
+        return savePost
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/service/PostServiceImpl.kt
@@ -1,8 +1,10 @@
 package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.service
 
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.*
-import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.PostsResponse.Companion.toResponse
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.model.PostTag
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository.HashTagRepository
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository.PostRepository
+import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.repository.PostTagRepository
 import com.teamsparta.exhibitionnewsfeed.domain.user.repository.UserRepository
 import com.teamsparta.exhibitionnewsfeed.exception.ModelNotFoundException
 import org.springframework.data.repository.findByIdOrNull
@@ -11,8 +13,11 @@ import org.springframework.stereotype.Service
 @Service
 class PostServiceImpl(
     private val postRepository: PostRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val hashTagRepository: HashTagRepository,
+    private val postTagRepository: PostTagRepository
 ) : PostService {
+
     override fun getPostById(postId: Long): PostResponse {
         val foundPost = postRepository.findByIdOrNull(postId) ?: throw ModelNotFoundException("Post", postId)
 
@@ -20,14 +25,25 @@ class PostServiceImpl(
     }
 
     override fun getAllPosts(): List<PostsResponse> {
-        return postRepository.findAllByOrderByCreatedAtDesc().map { it.toResponse() }
+        return postRepository.findAllByOrderByCreatedAtDesc().map { PostsResponse.from(it) }
     }
 
     override fun createPost(request: CreatePostRequest): PostsResponse {
         // TODO: 로그인 구현 후 nickname 가져오는 방식 수정
         val user = userRepository.findByIdOrNull(1L) ?: throw ModelNotFoundException("User", 1)
 
-        return postRepository.save(request.toEntity(user)).toResponse()
+        var savePost = postRepository.save(request.toEntity(user))
+        if (request.tagName.isNotBlank()) {
+            val saveHashTag = hashTagRepository.save(request.toHashTagEntity())
+            val postTag = postTagRepository.save<PostTag?>(
+                PostTag(
+                    post = savePost,
+                    hashTag = saveHashTag
+                )
+            )
+            savePost.postTag = mutableListOf(postTag)
+        }
+        return PostsResponse.from(savePost)
     }
 
     override fun updatePost(postId: Long, request: UpdatePostRequest): PostResponse {


### PR DESCRIPTION
## 작업 사항

Post 생성 시 해시태그(구분자 쉼표)를 입력받아 DB에 저장
중복일 경우 해당 hashTagId를 가져와서 PostTag 테이블에 저장
응답테스트 - 해시태그 리스트 출력


완료할 이슈: #23 