### PR TITLE
[Refactor-56]인증,인가 처리 방식 수정

### DIFF
--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/AuthArgumentResolver.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/AuthArgumentResolver.kt
@@ -25,21 +25,14 @@ class AuthArgumentResolver(
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
-    ): Any? {
+    ): AuthUser {
         val request: HttpServletRequest =
             webRequest.getNativeRequest(HttpServletRequest::class.java) ?: throw IllegalArgumentException()
         val token = request.getHeader(HttpHeaders.AUTHORIZATION)?.replace("Bearer ", "")?.trim() ?: ""
 
-        if (!jwtTokenProvider.validateToken(token)) {
-            throw IllegalArgumentException("Invalid Token")
-        }
+        if (!jwtTokenProvider.validateToken(token)) throw IllegalArgumentException("Invalid Token")
+        if (jwtTokenProvider.getSubject(token) != TokenType.ACCESS_TOKEN.name) throw IllegalArgumentException("ACCESS_TOKEN 아닙니다.")
 
-        val tokenType = when (jwtTokenProvider.getSubject(token)) {
-            "accessToken" -> TokenType.ACCESS_TOKEN
-            "refreshToken" -> TokenType.REFRESH_TOKEN
-            else -> throw IllegalArgumentException("Token not found")
-        }
-
-        return AuthUser(id = jwtTokenProvider.getUserId(token), token = token, tokenType = tokenType)
+        return AuthUser(id = jwtTokenProvider.getUserId(token), token = token)
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/AuthUser.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/AuthUser.kt
@@ -2,6 +2,5 @@ package com.teamsparta.exhibitionnewsfeed.domain.auth
 
 data class AuthUser(
     val id: Long,
-    val token: String,
-    val tokenType: TokenType
+    val token: String
 )

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/JwtTokenProvider.kt
@@ -20,19 +20,19 @@ class JwtTokenProvider {
     private val key: SecretKey = Keys.hmacShaKeyFor(SECRET_KEY.toByteArray(StandardCharsets.UTF_8))
 
     fun generateAccessToken(user: User): String {
-        return generateToken(user, "accessToken", Duration.ofMinutes(10))
+        return generateToken(user, TokenType.ACCESS_TOKEN, Duration.ofMinutes(10))
     }
 
     fun generateRefreshToken(user: User): String {
-        return generateToken(user, "refreshToken", Duration.ofDays(1))
+        return generateToken(user, TokenType.REFRESH_TOKEN, Duration.ofDays(1))
     }
 
-    private fun generateToken(user: User, subject: String, duration: Duration): String {
+    private fun generateToken(user: User, subject: TokenType, duration: Duration): String {
         val claims = Jwts.claims().add("userId", user.id).build()
         val now = Instant.now()
 
         return Jwts.builder()
-            .subject(subject)
+            .subject(subject.name)
             .issuer("team6.explorers")
             .issuedAt(Date.from(now))
             .expiration(Date.from(now.plus(duration)))

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/controller/AuthController.kt
@@ -2,7 +2,7 @@ package com.teamsparta.exhibitionnewsfeed.domain.auth.controller
 
 import com.teamsparta.exhibitionnewsfeed.domain.auth.AuthUser
 import com.teamsparta.exhibitionnewsfeed.domain.auth.RequestUser
-import com.teamsparta.exhibitionnewsfeed.domain.auth.TokenType
+import com.teamsparta.exhibitionnewsfeed.domain.auth.dto.UserPassword
 import com.teamsparta.exhibitionnewsfeed.domain.auth.service.AuthService
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.LoginRequest
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.LoginResponse
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/v1/auth")
 @RestController

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/controller/AuthController.kt
@@ -9,6 +9,7 @@ import com.teamsparta.exhibitionnewsfeed.domain.user.dto.LoginResponse
 import com.teamsparta.exhibitionnewsfeed.exception.UnauthorizedException
 import io.swagger.v3.oas.annotations.Parameter
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -24,15 +25,15 @@ class AuthController(private val authService: AuthService) {
     }
 
     @PostMapping("/new-token")
-    fun getNewAccessToken(@Parameter(hidden = true) @RequestUser authUser: AuthUser): ResponseEntity<Map<String, String>> {
+    fun getNewAccessToken(@RequestHeader header: HttpHeaders): ResponseEntity<Map<String, String>> {
+        val token = header.getOrEmpty("Authorization")[0]?.replace("Bearer ", "")?.trim() ?: ""
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(mapOf("accessToken" to authService.getNewAccessToken(authUser)))
+            .body(mapOf("accessToken" to authService.getNewAccessToken(token)))
     }
 
     @PostMapping("/logout")
     fun logout(@RequestUser @Valid authUser: AuthUser): ResponseEntity<Void> {
-        if (authUser.tokenType != TokenType.REFRESH_TOKEN) throw UnauthorizedException("유효한 토큰이 아닙니다.")
         authService.logout(authUser)
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/controller/AuthController.kt
@@ -41,4 +41,17 @@ class AuthController(private val authService: AuthService) {
             .status(HttpStatus.OK)
             .build()
     }
+
+    @PostMapping("/{userId}")
+    fun verifyPassword(
+        @PathVariable userId: Long,
+        @RequestUser @Parameter(hidden = true) authUser: AuthUser,
+        @RequestBody request: UserPassword
+    ): ResponseEntity<Unit> {
+        if (userId != authUser.id) throw UnauthorizedException("권한이 없습니다.")
+        if (!authService.verifyPassword(userId, request.password)) throw UnauthorizedException("비밀번호가 일치하지 않습니다.")
+
+        //TODO 암호화된 검증 토큰 response에 넣기
+        return ResponseEntity.status(HttpStatus.OK).build()
+    }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/dto/UserPassword.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/dto/UserPassword.kt
@@ -1,0 +1,3 @@
+package com.teamsparta.exhibitionnewsfeed.domain.auth.dto
+
+data class UserPassword(val password: String)

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/model/RefreshToken.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/model/RefreshToken.kt
@@ -1,10 +1,14 @@
 package com.teamsparta.exhibitionnewsfeed.domain.auth.model
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 
 @Entity
 class RefreshToken(
     @Id
-    val refreshToken: String
+    val refreshToken: String,
+
+    @Column(unique = true, nullable = false)
+    val userId: Long
 )

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/repository/RefreshTokenRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface RefreshTokenRepository : JpaRepository<RefreshToken, String> {
     fun existsByRefreshToken(refreshToken: String): Boolean
+    fun deleteByUserId(id: Long)
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/service/AuthService.kt
@@ -9,4 +9,5 @@ interface AuthService {
     fun login(request: LoginRequest): LoginResponse
     fun getNewAccessToken(authUser: AuthUser): String
     fun logout(authUser: AuthUser)
+    fun verifyPassword(userId: Long, password: String?): Boolean
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/service/AuthService.kt
@@ -7,7 +7,7 @@ import com.teamsparta.exhibitionnewsfeed.domain.user.dto.LoginResponse
 interface AuthService {
 
     fun login(request: LoginRequest): LoginResponse
-    fun getNewAccessToken(authUser: AuthUser): String
+    fun getNewAccessToken(token: String): String
     fun logout(authUser: AuthUser)
     fun verifyPassword(userId: Long, password: String?): Boolean
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/service/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/auth/service/AuthServiceImpl.kt
@@ -54,4 +54,10 @@ class AuthServiceImpl(
             refreshTokenRepository.findByIdOrNull(authUser.token) ?: throw UnauthorizedException("유효한 토큰이 아닙니다.")
         refreshTokenRepository.delete(refreshToken)
     }
+
+    override fun verifyPassword(userId: Long, password: String?): Boolean {
+        val user =
+            userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User id $userId not found.", userId)
+        return user.isValidPassword(password ?: "", passwordEncoder)
+    }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/likes/controller/CommentLikeController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/likes/controller/CommentLikeController.kt
@@ -2,7 +2,6 @@ package com.teamsparta.exhibitionnewsfeed.domain.likes.controller
 
 import com.teamsparta.exhibitionnewsfeed.domain.auth.AuthUser
 import com.teamsparta.exhibitionnewsfeed.domain.auth.RequestUser
-import com.teamsparta.exhibitionnewsfeed.domain.auth.TokenType
 import com.teamsparta.exhibitionnewsfeed.domain.likes.dto.CommentLikeRequest
 import com.teamsparta.exhibitionnewsfeed.domain.likes.service.LikeService
 import com.teamsparta.exhibitionnewsfeed.exception.UnauthorizedException
@@ -25,7 +24,6 @@ class CommentLikeController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @RequestBody commentLikeRequest: CommentLikeRequest
     ): ResponseEntity<Unit> {
-        checkAccessToken(authUser)
         if (authUser.id != commentLikeRequest.userId)
             throw UnauthorizedException("You are not allowed to use this comment like")
         likeService.likeComment(postId, commentId, authUser, commentLikeRequest.userId)
@@ -40,15 +38,10 @@ class CommentLikeController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @RequestBody commentLikeRequest: CommentLikeRequest
     ): ResponseEntity<Unit> {
-        checkAccessToken(authUser)
         if (authUser.id != commentLikeRequest.userId)
             throw UnauthorizedException("You are not allowed to use this comment like")
         likeService.removeCommentLike(postId, commentId, likeId, commentLikeRequest.userId)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
-    }
-
-    private fun checkAccessToken(authUser: AuthUser) {
-        if (authUser.tokenType != TokenType.ACCESS_TOKEN) throw UnauthorizedException("유효한 토큰이 아닙니다.")
     }
 }
 

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/likes/controller/PostLikeController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/likes/controller/PostLikeController.kt
@@ -2,10 +2,8 @@ package com.teamsparta.exhibitionnewsfeed.domain.likes.controller
 
 import com.teamsparta.exhibitionnewsfeed.domain.auth.AuthUser
 import com.teamsparta.exhibitionnewsfeed.domain.auth.RequestUser
-import com.teamsparta.exhibitionnewsfeed.domain.auth.TokenType
 import com.teamsparta.exhibitionnewsfeed.domain.likes.dto.PostLikeResponse
 import com.teamsparta.exhibitionnewsfeed.domain.likes.service.LikeService
-import com.teamsparta.exhibitionnewsfeed.exception.UnauthorizedException
 import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -22,7 +20,6 @@ class PostLikeController(
         @PathVariable postId: Long,
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
     ): ResponseEntity<Unit> {
-        checkAuth(authUser)
         likeService.likePost(postId, authUser)
 
         return ResponseEntity
@@ -35,9 +32,7 @@ class PostLikeController(
         @PathVariable likeId: Long,
         @PathVariable postId: Long,
         @RequestUser @Parameter(hidden = true) authUser: AuthUser
-    ):
-            ResponseEntity<Unit> {
-        checkAuth(authUser)
+    ): ResponseEntity<Unit> {
         likeService.removePostLike(likeId, postId)
 
         return ResponseEntity
@@ -48,9 +43,5 @@ class PostLikeController(
     @GetMapping("/posts/{postId}")
     fun getLikes(@PathVariable postId: Long): List<PostLikeResponse> {
         return likeService.getLikesByPostId(postId)
-    }
-
-    private fun checkAuth(authUser: AuthUser) {
-        if (authUser.tokenType != TokenType.ACCESS_TOKEN) throw UnauthorizedException("유효한 토큰이 아닙니다.")
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/comment/controller/CommentController.kt
@@ -2,12 +2,10 @@ package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.comment.controller
 
 import com.teamsparta.exhibitionnewsfeed.domain.auth.AuthUser
 import com.teamsparta.exhibitionnewsfeed.domain.auth.RequestUser
-import com.teamsparta.exhibitionnewsfeed.domain.auth.TokenType
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.comment.dto.CommentResponse
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.comment.dto.CreateCommentRequest
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.comment.dto.UpdateCommentRequest
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.comment.service.CommentService
-import com.teamsparta.exhibitionnewsfeed.exception.UnauthorizedException
 import io.swagger.v3.oas.annotations.Parameter
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -25,7 +23,6 @@ class CommentController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @RequestBody request: CreateCommentRequest
     ): ResponseEntity<CommentResponse> {
-        checkAccessToken(authUser)
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(commentService.createComment(postId, authUser, request))
@@ -38,7 +35,6 @@ class CommentController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @RequestBody @Valid request: UpdateCommentRequest
     ): ResponseEntity<CommentResponse> {
-        checkAccessToken(authUser)
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(commentService.updateComment(postId, commentId, authUser, request))
@@ -50,14 +46,9 @@ class CommentController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @PathVariable commentId: Long
     ): ResponseEntity<Unit> {
-        checkAccessToken(authUser)
         commentService.deleteComment(postId, commentId, authUser)
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .build()
-    }
-
-    private fun checkAccessToken(authUser: AuthUser) {
-        if (authUser.tokenType != TokenType.ACCESS_TOKEN) throw UnauthorizedException("유효한 토큰이 아닙니다.")
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/controller/PostController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/controller/PostController.kt
@@ -2,13 +2,11 @@ package com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.controller
 
 import com.teamsparta.exhibitionnewsfeed.domain.auth.AuthUser
 import com.teamsparta.exhibitionnewsfeed.domain.auth.RequestUser
-import com.teamsparta.exhibitionnewsfeed.domain.auth.TokenType
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.CreatePostRequest
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.PostResponse
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.PostsResponse
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.dto.UpdatePostRequest
 import com.teamsparta.exhibitionnewsfeed.domain.newsfeed.post.service.PostService
-import com.teamsparta.exhibitionnewsfeed.exception.UnauthorizedException
 import io.swagger.v3.oas.annotations.Parameter
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -51,8 +49,6 @@ class PostController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @Valid @RequestBody request: CreatePostRequest
     ): ResponseEntity<PostsResponse> {
-        checkAuth(authUser)
-
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(postService.createPost(authUser, request))
@@ -64,8 +60,6 @@ class PostController(
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @Valid @RequestBody request: UpdatePostRequest
     ): ResponseEntity<PostResponse> {
-        checkAuth(authUser)
-
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(postService.updatePost(postId, authUser, request))
@@ -76,16 +70,10 @@ class PostController(
         @PathVariable postId: Long,
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
     ): ResponseEntity<Unit> {
-        checkAuth(authUser)
-
         postService.deletePost(postId, authUser)
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .build()
-    }
-
-    private fun checkAuth(authUser: AuthUser) {
-        if (authUser.tokenType != TokenType.ACCESS_TOKEN) throw UnauthorizedException("유효한 토큰이 아닙니다.")
     }
 }
 

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/controller/UserController.kt
@@ -2,7 +2,6 @@ package com.teamsparta.exhibitionnewsfeed.domain.user.controller
 
 import com.teamsparta.exhibitionnewsfeed.domain.auth.AuthUser
 import com.teamsparta.exhibitionnewsfeed.domain.auth.RequestUser
-import com.teamsparta.exhibitionnewsfeed.domain.auth.TokenType
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.SignUpRequest
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.SignUpResponse
 import com.teamsparta.exhibitionnewsfeed.domain.user.dto.UpdateUserProfileRequest
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.*
 class UserController(
     private val userService: UserService
 ) {
-
     @PostMapping("/sign-up")
     fun signUp(@RequestBody @Valid request: SignUpRequest): ResponseEntity<SignUpResponse> {
         return ResponseEntity
@@ -35,33 +33,15 @@ class UserController(
             .body(userService.getProfile(userId))
     }
 
-    @PostMapping("/profile/{userId}/verify")
-    fun verifyPassword(
-        @PathVariable userId: Long,
-        @RequestUser @Parameter(hidden = true) authUser: AuthUser,
-        @RequestBody request: Map<String, String>
-    ): ResponseEntity<Any> {
-        checkAuth(userId, authUser)
-        if (!userService.verifyPassword(userId, request["password"])) throw UnauthorizedException("비밀번호가 일치하지 않습니다.")
-
-        //TODO 암호화된 검증 토큰 response에 넣기
-        return ResponseEntity.status(HttpStatus.OK).build()
-    }
-
     @PatchMapping("/profile/{userId}")
     fun updateProfile(
         @PathVariable userId: Long,
         @RequestUser @Parameter(hidden = true) authUser: AuthUser,
         @RequestBody request: UpdateUserProfileRequest
     ): ResponseEntity<UserProfileResponse> {
-        checkAuth(userId, authUser)
+        if (userId != authUser.id) throw UnauthorizedException("권한이 없습니다.")
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(userService.updateProfile(userId, request))
-    }
-
-    private fun checkAuth(userId: Long, authUser: AuthUser) {
-        if (userId != authUser.id) throw UnauthorizedException("권한이 없습니다.")
-        if (authUser.tokenType != TokenType.ACCESS_TOKEN) throw UnauthorizedException("유효한 토큰이 아닙니다.")
     }
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/service/UserService.kt
@@ -8,6 +8,5 @@ import com.teamsparta.exhibitionnewsfeed.domain.user.dto.UserProfileResponse
 interface UserService {
     fun signUp(request: SignUpRequest): SignUpResponse
     fun getProfile(userId: Long): UserProfileResponse
-    fun verifyPassword(userId: Long, password: String?): Boolean
     fun updateProfile(userId: Long, request: UpdateUserProfileRequest): UserProfileResponse
 }

--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/user/service/UserServiceImpl.kt
@@ -29,12 +29,6 @@ class UserServiceImpl(
         return UserProfileResponse.from(user)
     }
 
-    override fun verifyPassword(userId: Long, password: String?): Boolean {
-        val user =
-            userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User id $userId not found.", userId)
-        return user.isValidPassword(password ?: "", passwordEncoder)
-    }
-
     @Transactional
     override fun updateProfile(userId: Long, request: UpdateUserProfileRequest): UserProfileResponse {
         val user =


### PR DESCRIPTION
## 작업 사항
- AuthArgumentResolver에서 @AuthUser가 ACCESS_TOKEN 만 담당하도록 수정
- RefreshToken 엔티티에 userId 컬럼 추가
- 로그아웃, 엑세스 토큰 재발급 api에서는 @RequestHeader를 사용하여 토큰 정보를 가져와 검증 수행
- 로그아웃시 해당 userId를 가진 refreshToken 삭제

resolved: #56 
