### PR TITLE
🐛 update_at 자동으로 입력 안되는 오류 수정

### DIFF
--- a/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/BaseTime.kt
+++ b/src/main/kotlin/com/teamsparta/exhibitionnewsfeed/domain/newsfeed/post/model/BaseTime.kt
@@ -4,16 +4,18 @@ import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 @MappedSuperclass
-@EntityListeners
+@EntityListeners(AuditingEntityListener::class)
 abstract class BaseTime {
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     val createdAt: LocalDateTime? = null
 
-    @CreationTimestamp
-    @Column(nullable = false)
-    val updatedAt: LocalDateTime? = null
+    @LastModifiedDate
+    @Column(nullable = true)
+    var updatedAt: LocalDateTime? = null
 }


### PR DESCRIPTION
## 작업 사항

- `BaseTime` 엔티티 `updatedAt` 컬럼 `@CreationTimestamp` -> `@LastModifiedDate`로 수정
- `BaseTime` 엔티티에 `@EntityListeners(AuditingEntityListener::class)` 적용

resolved: #60 
